### PR TITLE
修复旋转屏幕时节拍器中断

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
             android:taskAffinity="${applicationId}" />
         <activity
             android:name=".MetronomeActivity"
-            android:configChanges="orientation"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/Theme.SimpleBeat"
             android:exported="true"
             android:taskAffinity="${applicationId}"


### PR DESCRIPTION
## 变更说明

修复旋转屏幕时节拍器播放被中断的问题。

这次只修改了 `AndroidManifest.xml` 中 `MetronomeActivity` 的 `configChanges`：

- 从 `orientation`
- 改为 `orientation|screenSize`

## 原因

设备旋转时，系统不一定只触发方向变化，也可能同时触发 `screenSize` 变化。

当前 `MetronomeActivity` 只声明处理了 `orientation`，没有处理 `screenSize`。  
这样在部分设备或系统版本上，旋转时 Activity 仍然可能被重建，导致当前播放被中断。

## 修改内容

将：

```xml
android:configChanges="orientation"

改为：

android:configChanges="orientation|screenSize"
```

验证
开始播放节拍器
旋转屏幕
确认播放不会中断